### PR TITLE
fix: update checkout logic due to Stripe API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ bundle install
 
 This will grab all the dependencies.
 
+Then, you'll want to add your Stripe API keys to **/config/secrets.yml** to allow the Stripe API to handle payments.
+
 ## Usage
 
 You'll need to migrate the db for the project to work by running the following:

--- a/app/views/checkout/cancel.html.erb
+++ b/app/views/checkout/cancel.html.erb
@@ -1,1 +1,3 @@
-<p>Sorry something went wrong.</p>
+<p>Your order has been cancelled.</p>
+
+<button class="btn btn-primary" onclick="window.location.href = '/';">View the store</button>

--- a/app/views/checkout/success.html.erb
+++ b/app/views/checkout/success.html.erb
@@ -1,4 +1,4 @@
-<p>Thanks for your ETH!</p>
+<p>Thanks for your money!</p>
 
 <%= debug @order_details %>
 <%= debug @session %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -146,7 +146,6 @@
         <p class="text-center text-muted small">Silph Co. <span>🚀</span> - Copywrong <%= Time.current.year %></p>
       </footer>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
     <script src="https://js.stripe.com/v3"></script>
   </body>
 </html>

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,6 +1,6 @@
 Rails.configuration.stripe = {
-  publishable_key: ENV["PUBLISHABLE_KEY"],
-  secret_key:      ENV["SECRET_KEY"]
+  publishable_key: Rails.application.secrets.stripe_publishable_key,
+  secret_key:      Rails.application.secrets.stripe_secret_key
 }
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,7 @@
+development:
+  stripe_secret_key: "<YOURKEY>"
+  stripe_publishable_key: "<YOURKEY>"
+
+production:
+  stripe_secret_key: "<YOURKEY>"
+  stripe_publishable_key: "<YOURKEY>"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,3 +95,5 @@ if Rails.env.development?
   AdminUser.create!(email: "admin@silph.co", password: "teamrocket",
   password_confirmation: "teamrocket")
 end
+
+logger.info "Created #{AdminUser.count} Admin User"


### PR DESCRIPTION
When I introduced new changes to this repo to support Apple Silicon, I missed the Stripe API getting updated as part of the packages, which broke the checkout workflow.

This set of changes goes through the logic to get the checkout flow working as well as update the checkout functionality to Stripes more modern API standards.